### PR TITLE
Bump up default consul version to 1.0.0

### DIFF
--- a/src/main/groovy/com/pszymczyk/consul/ConsulPorts.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulPorts.groovy
@@ -6,15 +6,13 @@ class ConsulPorts {
 
     final int httpPort
     final int dnsPort
-    final int rpcPort
     final int serfLanPort
     final int serfWanPort
     final int serverPort
 
-    private ConsulPorts(int httpPort, int dnsPort, int rpcPort, int serfLanPort, int serfWanPort, int serverPort) {
+    private ConsulPorts(int httpPort, int dnsPort, int serfLanPort, int serfWanPort, int serverPort) {
         this.httpPort = httpPort
         this.dnsPort = dnsPort
-        this.rpcPort = rpcPort
         this.serfLanPort = serfLanPort
         this.serfWanPort = serfWanPort
         this.serverPort = serverPort
@@ -28,7 +26,6 @@ class ConsulPorts {
 
         private int httpPort = -1
         private int dnsPort = -1
-        private int rpcPort = -1
         private int serfLanPort = -1
         private int serfWanPort = -1
         private int serverPort = -1
@@ -40,14 +37,13 @@ class ConsulPorts {
             return new ConsulPorts(
                     randomIfNotSet(httpPort),
                     randomIfNotSet(dnsPort),
-                    randomIfNotSet(rpcPort),
                     randomIfNotSet(serfLanPort),
                     randomIfNotSet(serfWanPort),
                     randomIfNotSet(serverPort)
             )
         }
 
-        private int randomIfNotSet(int port) {
+        private static int randomIfNotSet(int port) {
             return port > 0 ? port : Ports.nextAvailable()
         }
 
@@ -58,11 +54,6 @@ class ConsulPorts {
 
         ConsulPortsBuilder withDnsPort(int dnsPort) {
             this.dnsPort = dnsPort
-            return this
-        }
-
-        ConsulPortsBuilder withRpcPort(int rpcPort) {
-            this.rpcPort = rpcPort
             return this
         }
 
@@ -84,7 +75,6 @@ class ConsulPorts {
         ConsulPortsBuilder fromConsulPorts(ConsulPorts consulPorts) {
             this.httpPort = consulPorts.httpPort
             this.dnsPort = consulPorts.dnsPort
-            this.rpcPort = consulPorts.rpcPort
             this.serfLanPort = consulPorts.serfLanPort
             this.serfWanPort = consulPorts.serfWanPort
             this.serverPort = consulPorts.serverPort

--- a/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
@@ -61,10 +61,6 @@ class ConsulProcess implements AutoCloseable {
         consulPorts.dnsPort
     }
 
-    int getRpcPort() {
-        consulPorts.rpcPort
-    }
-
     int getSerfLanPort() {
         consulPorts.serfLanPort
     }

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarter.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarter.groovy
@@ -67,7 +67,6 @@ class ConsulStarter {
             switch (it.key) {
                 case "dns": ports = ports.withDnsPort(it.value); break
                 case "http": ports = ports.withHttpPort(it.value); break
-                case "rpc": ports = ports.withRpcPort(it.value); break
                 case "serf_lan": ports = ports.withSerfLanPort(it.value); break
                 case "serf_wan": ports = ports.withSerfWanPort(it.value); break
                 case "server": ports = ports.withServerPort(it.value); break
@@ -179,7 +178,6 @@ class ConsulStarter {
             {
                 "ports": {
                     "dns": ${consulPorts.dnsPort},
-                    "rpc": ${consulPorts.rpcPort},
                     "serf_lan": ${consulPorts.serfLanPort},
                     "serf_wan": ${consulPorts.serfWanPort},
                     "server": ${consulPorts.serverPort}

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
@@ -11,7 +11,7 @@ class ConsulStarterBuilder {
     private Path downloadDir
     private Path configDir
     private String customConfig
-    private String consulVersion = '0.7.5'
+    private String consulVersion = '1.0.0'
     private LogLevel logLevel = LogLevel.ERR
     private ConsulPorts.ConsulPortsBuilder consulPortsBuilder = ConsulPorts.consulPorts()
     private String startJoin

--- a/src/main/groovy/com/pszymczyk/consul/infrastructure/SimpleConsulClient.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/infrastructure/SimpleConsulClient.groovy
@@ -35,7 +35,7 @@ class SimpleConsulClient {
     }
 
     void deregister(String id) {
-        http.get(path: "/v1/agent/service/deregister/$id", contentType: ContentType.ANY)
+        http.put(path: "/v1/agent/service/deregister/$id", contentType: ContentType.ANY)
     }
 
     void clearKvStore() {
@@ -57,7 +57,7 @@ class SimpleConsulClient {
         response.getData().each {
             def id = it.key
 
-            http.get(path: "/v1/agent/check/deregister/$id", contentType: ContentType.ANY)
+            http.put(path: "/v1/agent/check/deregister/$id", contentType: ContentType.ANY)
         }
     }
 }

--- a/src/main/groovy/com/pszymczyk/consul/junit/ConsulResource.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/junit/ConsulResource.groovy
@@ -49,10 +49,6 @@ class ConsulResource extends ExternalResource {
         process.dnsPort
     }
 
-    int getRpcPort() {
-        process.rpcPort
-    }
-
     int getSerfLanPort() {
         process.serfLanPort
     }

--- a/src/test/groovy/com/pszymczyk/consul/ConsulPortsTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulPortsTest.groovy
@@ -11,7 +11,6 @@ class ConsulPortsTest extends Specification {
 
         then:
         consulPorts.dnsPort
-        consulPorts.rpcPort
         consulPorts.serfLanPort
         consulPorts.serfWanPort
         consulPorts.serverPort

--- a/src/test/groovy/com/pszymczyk/consul/ConsulStarterNodeNameIdTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulStarterNodeNameIdTest.groovy
@@ -1,12 +1,11 @@
 package com.pszymczyk.consul
 
 import com.ecwid.consul.v1.ConsulClient
-import spock.lang.Ignore
 import spock.lang.Specification
 
 class ConsulStarterNodeNameIdTest extends Specification {
 
-    def "should generate random id and name by default"() {
+    def "should generate random name by default"() {
         when:
         ConsulProcess consul1 = ConsulStarterBuilder.consulStarter().build().start()
         String name1 = new ConsulClient("localhost", consul1.httpPort)

--- a/src/test/groovy/com/pszymczyk/consul/ConsulStarterNodeNameIdTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulStarterNodeNameIdTest.groovy
@@ -1,49 +1,28 @@
 package com.pszymczyk.consul
 
 import com.ecwid.consul.v1.ConsulClient
-import groovy.json.JsonParserType
-import groovy.json.JsonSlurper
+import spock.lang.Ignore
 import spock.lang.Specification
 
-public class ConsulStarterNodeNameIdTest extends Specification {
+class ConsulStarterNodeNameIdTest extends Specification {
 
     def "should generate random id and name by default"() {
         when:
         ConsulProcess consul1 = ConsulStarterBuilder.consulStarter().build().start()
         String name1 = new ConsulClient("localhost", consul1.httpPort)
                 .agentSelf.value.config.nodeName;
-        String id1 = new ConsulClient("localhost", consul1.httpPort)
-                .agentSelf.value.config.nodeId
 
         ConsulProcess consul2 = ConsulStarterBuilder.consulStarter().build().start()
         String name2 = new ConsulClient("localhost", consul2.httpPort)
                 .agentSelf.value.config.nodeName;
-        String id2 = new ConsulClient("localhost", consul2.httpPort)
-                .agentSelf.value.config.nodeId
 
         then:
         name1 != name2
-        id1 != id2
 
         cleanup:
         consul1.close()
         consul2.close()
 
-    }
-
-    def "should use user defined node id"() {
-        when:
-        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
-                .withCustomConfig("{\"node_id\":\"01234567-890a-bcde-f012-34567890abcd\"}")
-                .build().start()
-        String id = new ConsulClient("localhost", consul.httpPort)
-                .agentSelf.value.config.nodeId
-
-        then:
-        id == "01234567-890a-bcde-f012-34567890abcd"
-
-        cleanup:
-        consul.close()
     }
 
     def "should use user defined node name"() {

--- a/src/test/groovy/com/pszymczyk/consul/ConsulStarterTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulStarterTest.groovy
@@ -62,11 +62,7 @@ class ConsulStarterTest extends Specification {
         consul.reset()
 
         then:
-        consulClient.getAgentServices().value.size() == 1
-        consulClient.getAgentServices().value.values().with {
-            it.size() == 1
-            it.first().service == 'consul'
-        }
+        consulClient.getAgentServices().value.size() == 0
     }
 
     def "should remove all data from kv store when reset Consul process"() {
@@ -97,7 +93,7 @@ class ConsulStarterTest extends Specification {
         given:
         NewCheck newCheck = new NewCheck()
         newCheck.name = "test-check"
-        newCheck.ttl = "15s"
+        newCheck.interval = "10s"
         newCheck.http = "http://example.com"
 
         consulClient.agentCheckRegister(newCheck)


### PR DESCRIPTION
* ConsulStarterTest."should remove all services when reset Consul process": consulClient.getAgentServices().value.size() after reset returns 0 now.
* ConsulStarterTest."should deregister all checks when reset Consul process" fails unless I change newCheck.ttl to newCheck.interval
* ConsulStarterNodeNameIdTest removed tests which checks NodeId, since it was moved to DebugConfig.