### PR TITLE
get CONSUL_BINARY_CDN from system.property

### DIFF
--- a/src/main/groovy/com/pszymczyk/consul/infrastructure/HttpBinaryRepository.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/infrastructure/HttpBinaryRepository.groovy
@@ -14,7 +14,8 @@ class HttpBinaryRepository {
     File getConsulBinaryArchive(String version, File file) {
         httpsProtocolsSetter.setRequiredTls(System.getProperty("java.version"), System.getProperty("https.protocols"))
         String os = OsResolver.resolve()
-        String cdn = System.getenv(CONSUL_BINARY_CDN) != null ? System.getenv(CONSUL_BINARY_CDN) : CONSUL_DEFAULT_CDN;
+        String cdn = System.getenv(CONSUL_BINARY_CDN) != null ? System.getenv(CONSUL_BINARY_CDN)
+                : System.getProperty(CONSUL_BINARY_CDN) != null ? System.getProperty(CONSUL_BINARY_CDN) : CONSUL_DEFAULT_CDN;
         String url = "${cdn}${version}/consul_${version}_${os}_amd64.zip"
         OutputStream outputStream = file.newOutputStream()
         outputStream << new URL(url).openStream()


### PR DESCRIPTION
In certain cases I need to configure `CONSUL_BINARY_CDN` programmatically, but system environments are read-only 