### PR TITLE
update sample content of basic_config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,14 @@ Configuration file is stored in `/$tmp/embedded-consul-config-dir$randomNumber/b
 
     {
         "ports": {
-            "dns": 64294,
-            "rpc": 64295,
-            "serf_lan": 64296,
-            "serf_wan": 64297,
-            "server": 64298
+            "dns": 50084,
+            "serf_lan": 50085,
+            "serf_wan": 50086,
+            "server": 50087
+        },
+        "disable_update_check": true,
+        "performance": {
+            "raft_multiplier": 1
         }
     }
 


### PR DESCRIPTION
No port for rpc configurable now 

Consul docs: [Ports Used](https://www.consul.io/docs/agent/options.html#ports)