### PR TITLE
making it possible to handle the logs of consul with slf4j Logger (#60)

### DIFF
--- a/src/main/groovy/com/pszymczyk/consul/ConsulLogHandler.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulLogHandler.groovy
@@ -1,0 +1,94 @@
+package com.pszymczyk.consul
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
+class ConsulLogHandler {
+
+    private static final String CONSUL_LOG_FORMAT = /^(.+?)\[(\w+?)\]\s*(.+)$/
+    private static final String LOGGING_THREAD_NAME = "embedded-consul"
+
+    private final Logger consulLogger
+    private final ExecutorService logExecutor
+
+    private Future<?> logHandle
+
+    ConsulLogHandler(final Logger customLogger) {
+        this.consulLogger = customLogger ?: LoggerFactory.getLogger(ConsulStarter.class)
+        this.logExecutor = Executors.newSingleThreadExecutor({ runnable ->
+            Thread thread = new Thread(runnable)
+            thread.setName(LOGGING_THREAD_NAME)
+            return thread
+        })
+    }
+
+    private static def parseConsulLog(String line) {
+        LogLevel currentLevel = LogLevel.INFO
+        String message = line
+
+        def lineGroup = (line =~ CONSUL_LOG_FORMAT)
+        if (lineGroup.matches() && lineGroup.hasGroup()) {
+            def token = lineGroup[0]
+            if (token.size() >= 4) {
+                String levelToken = token[2]
+                String messageToken = token[3]
+
+                currentLevel = LogLevel.valueOf(levelToken) ?: LogLevel.INFO
+                message = messageToken
+            }
+        }
+
+        return [currentLevel, message]
+    }
+
+    def handleStream(final InputStream logStream) {
+        def reader = new InputStreamReader(logStream)
+        logHandle = logExecutor.submit({ ->
+            reader.eachLine { line ->
+                try {
+                    def (currentLevel, message) = parseConsulLog(line)
+
+                    switch (currentLevel) {
+                        case LogLevel.TRACE:
+                            consulLogger.trace(message)
+                            break
+                        case LogLevel.DEBUG:
+                            consulLogger.debug(message)
+                            break
+                        case LogLevel.WARN:
+                            consulLogger.warn(message)
+                            break
+                        case LogLevel.ERR:
+                            consulLogger.error(message)
+                            break
+                        default:
+                            consulLogger.info(message)
+                    }
+                } catch (Exception e) {
+                    consulLogger.error("logging error: ", e)
+                    return
+                }
+            }
+            consulLogger.debug("log stream encounter EOF")
+        })
+
+        return logHandle
+    }
+
+    void close() {
+        if (logHandle != null) {
+            logHandle.cancel(false)
+        }
+
+        logExecutor.shutdown()
+        final boolean done = logExecutor.awaitTermination(10, TimeUnit.SECONDS)
+        if (!done) {
+            logExecutor.shutdownNow()
+        }
+    }
+}

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarter.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarter.groovy
@@ -21,14 +21,16 @@ class ConsulStarter {
     private final Path dataDir
     private final Path downloadDir
     private final Path configDir
-    private final String customConfig;
-    private final Object decodedCustomConfig;
+    private final String customConfig
+    private final Object decodedCustomConfig
     private final String consulVersion
     private final LogLevel logLevel
+    private final Logger customLogger
     private final ConsulPorts consulPorts
     private final String startJoin
     private final String advertise
     private final String client
+    private final ConsulLogHandler logHandler
 
     private boolean started = false
 
@@ -42,11 +44,13 @@ class ConsulStarter {
                   String consulVersion,
                   String customConfig,
                   LogLevel logLevel,
+                  Logger customLogger,
                   ConsulPorts.ConsulPortsBuilder ports,
                   String startJoin,
                   String advertise,
                   String client) {
         this.logLevel = logLevel
+        this.customLogger = customLogger
         this.configDir = configDir
         this.customConfig = customConfig
         this.decodedCustomConfig = parseCustomConfig(customConfig)
@@ -58,6 +62,8 @@ class ConsulStarter {
         this.advertise = advertise
         this.client = client
         makeDI()
+
+        this.logHandler = new ConsulLogHandler(customLogger)
     }
 
     private ConsulPorts mergePorts(ConsulPorts.ConsulPortsBuilder ports) {
@@ -133,12 +139,15 @@ class ConsulStarter {
             command += ["-node=" + randomNodeName()]
         }
 
-        ConsulProcess process = new ConsulProcess(dataDir, consulPorts, advertise,
-                new ProcessBuilder()
-                        .directory(downloadDir.toFile())
-                        .command(command)
-                        .inheritIO()
-                        .start())
+        Process innerProcess = new ProcessBuilder()
+            .directory(downloadDir.toFile())
+            .command(command)
+            .inheritIO()
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .start()
+
+        logHandler.handleStream(innerProcess.getInputStream())
+        ConsulProcess process = new ConsulProcess(dataDir, consulPorts, advertise, innerProcess)
 
         logger.info("Starting Consul process on port {}", consulPorts.httpPort)
         new ConsulWaiter(consulPorts.httpPort).awaitUntilConsulStarted()
@@ -209,7 +218,7 @@ class ConsulStarter {
     }
 
     private static String randomHex(int len) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder()
         for (int i = 0; i < len; i++) {
             sb.append(Long.toHexString(random.nextInt(16)));
         }

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
@@ -1,5 +1,7 @@
 package com.pszymczyk.consul
 
+import org.slf4j.Logger
+
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -13,6 +15,7 @@ class ConsulStarterBuilder {
     private String customConfig
     private String consulVersion = '1.0.2'
     private LogLevel logLevel = LogLevel.ERR
+    private Logger customLogger
     private ConsulPorts.ConsulPortsBuilder consulPortsBuilder = ConsulPorts.consulPorts()
     private String startJoin
     private String advertise = "127.0.0.1"
@@ -28,6 +31,11 @@ class ConsulStarterBuilder {
 
     ConsulStarterBuilder withLogLevel(LogLevel logLevel) {
         this.logLevel = logLevel
+        this
+    }
+
+    ConsulStarterBuilder withLogger(Logger customLogger) {
+        this.customLogger = customLogger
         this
     }
 
@@ -89,6 +97,7 @@ class ConsulStarterBuilder {
                 consulVersion,
                 customConfig,
                 logLevel,
+                customLogger,
                 consulPortsBuilder,
                 startJoin,
                 advertise,

--- a/src/test/groovy/com/pszymczyk/consul/ConsulLogHandlerTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulLogHandlerTest.groovy
@@ -1,0 +1,106 @@
+package com.pszymczyk.consul
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
+class ConsulLogHandlerTest extends Specification {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConsulLogHandlerTest.class)
+
+    ConsulLogHandler handler
+    Logger mockLogger
+    PipedOutputStream output
+    Future<?> loggingHandle
+
+    def setup() {
+        this.mockLogger = Mock(Logger.class)
+        this.handler = new ConsulLogHandler(mockLogger)
+        this.output = new PipedOutputStream()
+
+        InputStream input = new PipedInputStream(this.output)
+        this.loggingHandle = handler.handleStream(input)
+    }
+
+    def "should create instance successfully with null"() {
+        when:
+        final ConsulLogHandler handler = new ConsulLogHandler(null)
+
+        then:
+        handler != null
+    }
+
+    def "should handle consul log with slf4j logger"() {
+        given:
+        final PrintWriter writer = output.newPrintWriter()
+        final String testCase = "2018/05/21 14:35:47 [DEBUG] Skipping remote check \"serfHealth\" since it is managed automatically"
+        final CompletableFuture<Boolean> handle = new CompletableFuture<>()
+
+        when:
+        logger.debug("testCase: {}", testCase)
+        writer.println(testCase)
+        writer.flush()
+        handle.get(10, TimeUnit.SECONDS)
+
+        then:
+        1 * mockLogger.debug("Skipping remote check \"serfHealth\" since it is managed automatically") >>
+            { args -> handle.complete(true) }
+    }
+
+    def "should handle consul startup log with slf4j logger"() {
+        given:
+        final PrintWriter writer = output.newPrintWriter()
+        final String testCase = "==> Starting Consul agent..."
+        final CompletableFuture<Boolean> handle = new CompletableFuture<>()
+
+        when:
+        logger.debug("testCase: {}", testCase)
+        writer.println(testCase)
+        writer.flush()
+        handle.get(10, TimeUnit.SECONDS)
+
+        then:
+        1 * mockLogger.info("==> Starting Consul agent...") >>
+            { args -> handle.complete(true) }
+    }
+
+    def "should handle logs"() {
+        given:
+        final PrintWriter writer = output.newPrintWriter()
+        final String testCase = "==> Starting Consul agent...\n" +
+            "==> Consul agent running!\n" +
+            "           Version: 'v1.0.1'\n" +
+            "           Node ID: 'c47ec383-bceb-1013-14f2-d3fd095c5dbe'\n" +
+            "         Node name: 'testNode'\n" +
+            "        Datacenter: 'dc1' (Segment: '<all>')\n" +
+            "            Server: true (Bootstrap: false)\n" +
+            "       Client Addr: [127.0.0.1] (HTTP: 8500, HTTPS: -1, DNS: 8600)\n" +
+            "      Cluster Addr: 127.0.0.1 (LAN: 8301, WAN: 8302)\n" +
+            "           Encrypt: Gossip: false, TLS-Outgoing: false, TLS-Incoming: false\n" +
+            "\n" +
+            "==> Log data will now stream in as it occurs:\n" +
+            "\n" +
+            "    2018/05/21 14:35:46 [DEBUG] Using random ID \"c47ec383-bceb-1013-14f2-d3fd095c5dbe\" as node ID\n" +
+            "    2018/05/21 14:35:46 [INFO] raft: Initial configuration (index=1): [{Suffrage:Voter ID:c47ec383-bceb-1013-14f2-d3fd095c5dbe Address:127.0.0.1:8300}]\n" +
+            "    2018/05/21 14:35:46 [INFO] raft: Node at 127.0.0.1:8300 [Follower] entering Follower state (Leader: \"\")\n" +
+            "    2018/05/21 14:35:46 [INFO] serf: EventMemberJoin: testNode.dc1 127.0.0.1\n" +
+            "    2018/05/21 14:35:46 [INFO] serf: EventMemberJoin: testNode 127.0.0.1\n" +
+            "    2018/05/21 14:35:46 [INFO] consul: Adding LAN server testNode (Addr: tcp/127.0.0.1:8300) (DC: dc1)\n" +
+            "    2018/05/21 14:35:46 [INFO] consul: Handled member-join event for server \"testNode.dc1\" in area \"wan\"\n"
+
+        when:
+        logger.debug("testCase: {}", testCase)
+        writer.print(testCase)
+        writer.flush()
+        Thread.sleep(1_000L)
+
+        then:
+        13 * mockLogger.info(_ as String)
+        1 * mockLogger.debug(_ as String)
+        6 * mockLogger.info(_ as String)
+    }
+}

--- a/src/test/groovy/com/pszymczyk/consul/ConsulLogHandlerTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulLogHandlerTest.groovy
@@ -4,9 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
 
 class ConsulLogHandlerTest extends Specification {
 
@@ -38,34 +36,30 @@ class ConsulLogHandlerTest extends Specification {
         given:
         final PrintWriter writer = output.newPrintWriter()
         final String testCase = "2018/05/21 14:35:47 [DEBUG] Skipping remote check \"serfHealth\" since it is managed automatically"
-        final CompletableFuture<Boolean> handle = new CompletableFuture<>()
 
         when:
         logger.debug("testCase: {}", testCase)
         writer.println(testCase)
         writer.flush()
-        handle.get(10, TimeUnit.SECONDS)
+        Thread.sleep(1_000L)
 
         then:
-        1 * mockLogger.debug("Skipping remote check \"serfHealth\" since it is managed automatically") >>
-            { args -> handle.complete(true) }
+        1 * mockLogger.debug("Skipping remote check \"serfHealth\" since it is managed automatically")
     }
 
     def "should handle consul startup log with slf4j logger"() {
         given:
         final PrintWriter writer = output.newPrintWriter()
         final String testCase = "==> Starting Consul agent..."
-        final CompletableFuture<Boolean> handle = new CompletableFuture<>()
 
         when:
         logger.debug("testCase: {}", testCase)
         writer.println(testCase)
         writer.flush()
-        handle.get(10, TimeUnit.SECONDS)
+        Thread.sleep(1_000L)
 
         then:
-        1 * mockLogger.info("==> Starting Consul agent...") >>
-            { args -> handle.complete(true) }
+        1 * mockLogger.info("==> Starting Consul agent...")
     }
 
     def "should handle logs"() {


### PR DESCRIPTION
- add `ConsulLogHandler`
- `ConsulStarter`, `ConsulStarterBuilder` add customLogger field
- `ConsulStarter.start()` modified to handle logs