### PR TITLE
Support consul token

### DIFF
--- a/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
@@ -1,7 +1,8 @@
 package com.pszymczyk.consul
 
 import com.pszymczyk.consul.infrastructure.ConsulWaiter
-import com.pszymczyk.consul.infrastructure.SimpleConsulClient
+import com.pszymczyk.consul.infrastructure.client.ConsulClientFactory
+import com.pszymczyk.consul.infrastructure.client.SimpleConsulClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -24,7 +25,7 @@ class ConsulProcess implements AutoCloseable {
         this.address = address
         this.process = process
         this.token = token
-        this.simpleConsulClient = new SimpleConsulClient(address, httpPort, token)
+        this.simpleConsulClient = ConsulClientFactory.newClient(address, httpPort, token)
     }
     /**
      * Deregister all services except consul.

--- a/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
@@ -16,13 +16,15 @@ class ConsulProcess implements AutoCloseable {
     private final String address
     private final Process process
     private final SimpleConsulClient simpleConsulClient
+    private final String token
 
-    ConsulProcess(Path dataDir, ConsulPorts consulPorts, String address, Process process) {
+    ConsulProcess(Path dataDir, ConsulPorts consulPorts, String address, String token, Process process) {
         this.dataDir = dataDir
         this.consulPorts = consulPorts
         this.address = address
         this.process = process
-        this.simpleConsulClient = new SimpleConsulClient(address, httpPort)
+        this.token = token
+        this.simpleConsulClient = new SimpleConsulClient(address, httpPort, token)
     }
     /**
      * Deregister all services except consul.
@@ -40,7 +42,7 @@ class ConsulProcess implements AutoCloseable {
 
         process.destroy()
 
-        new ConsulWaiter(address, consulPorts.httpPort).awaitUntilConsulStopped() ?
+        new ConsulWaiter(address, consulPorts.httpPort, token).awaitUntilConsulStopped() ?
                 logger.info("Stopped Consul process") :
                 logger.warn("Can't stop Consul process running on port {}", consulPorts.httpPort)
     }

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
@@ -21,6 +21,8 @@ class ConsulStarterBuilder {
     private String bind
     private String advertise = "127.0.0.1"
     private String client = "127.0.0.1"
+    private String token
+    private Integer waitTimeout = 30
 
     private ConsulStarterBuilder() {
 
@@ -95,6 +97,17 @@ class ConsulStarterBuilder {
         this
     }
 
+    ConsulStarterBuilder withToken(String token) {
+        this.token = token
+        this
+    }
+
+    ConsulStarterBuilder withWaitTimeout(Integer timeoutSeconds) {
+        this.waitTimeout = timeoutSeconds
+        this
+    }
+
+
     ConsulStarter build() {
         applyDefaults()
         return new ConsulStarter(dataDir,
@@ -108,7 +121,9 @@ class ConsulStarterBuilder {
                 startJoin,
                 advertise,
                 client,
-                bind)
+                bind,
+                token,
+                waitTimeout)
     }
 
     private void applyDefaults() {

--- a/src/main/groovy/com/pszymczyk/consul/infrastructure/ConsulWaiter.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/infrastructure/ConsulWaiter.groovy
@@ -15,14 +15,22 @@ class ConsulWaiter {
     private final int port
 
     ConsulWaiter(String host, int port) {
-        this(host, port, DEFAULT_WAITING_TIME_IN_SECONDS)
+        this(host, port, null, DEFAULT_WAITING_TIME_IN_SECONDS)
+    }
+
+    ConsulWaiter(String host, int port, String token) {
+        this(host, port, token, DEFAULT_WAITING_TIME_IN_SECONDS)
     }
 
     ConsulWaiter(String host, int port, int timeoutInSeconds) {
+        this(host, port, null, timeoutInSeconds)
+    }
+
+    ConsulWaiter(String host, int port, String token, int timeoutInSeconds) {
         this.timeoutMilis = TimeUnit.SECONDS.toMillis(timeoutInSeconds as long)
         this.host = host
         this.port = port
-        this.simpleConsulClient = new SimpleConsulClient(host, port)
+        this.simpleConsulClient = new SimpleConsulClient(host, port, token)
     }
 
     void awaitUntilConsulStarted() {

--- a/src/main/groovy/com/pszymczyk/consul/infrastructure/client/ConsulClientFactory.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/infrastructure/client/ConsulClientFactory.groovy
@@ -1,0 +1,32 @@
+package com.pszymczyk.consul.infrastructure.client
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.HttpResponseDecorator
+import groovyx.net.http.RESTClient
+
+class ConsulClientFactory {
+
+    static SimpleConsulClient newClient(String host, int httpPort, String token) {
+        RESTClient restClient = new RESTClient("http://$host:$httpPort")
+        if (token != null) {
+            restClient.setHeaders('X-Consul-Token': token)
+            extendParser(restClient)
+        }
+        return new SimpleConsulClient(restClient)
+    }
+
+    /**
+     * Substitutes default parser to handle non-json responses in case of error
+     */
+    private static extendParser(RESTClient restClient) {
+        def originalParser = restClient.parser.getAt(ContentType.JSON)
+        restClient.parser.putAt(ContentType.JSON, { HttpResponseDecorator resp ->
+            if (resp.status >= 200 && resp.status < 300 ){
+                return originalParser(resp)
+            } else {
+                throw new GroovyRuntimeException("Unexpected response status code: ${resp.status}:" +
+                        " ${resp.getEntity().getContent().getText("UTF-8")}")
+            }
+        })
+    }
+}

--- a/src/main/groovy/com/pszymczyk/consul/infrastructure/client/SimpleConsulClient.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/infrastructure/client/SimpleConsulClient.groovy
@@ -1,4 +1,4 @@
-package com.pszymczyk.consul.infrastructure
+package com.pszymczyk.consul.infrastructure.client
 
 import groovyx.net.http.ContentType
 import groovyx.net.http.EncoderRegistry
@@ -12,25 +12,9 @@ class SimpleConsulClient {
     private static final String NO_LEADER_ELECTED_RESPONSE = ""
 
     private final RESTClient http
-    private final String token
 
-    SimpleConsulClient(String host, int httpPort, String token) {
-        this.http = new RESTClient("http://$host:$httpPort")
-
-        this.token = token
-        if (token != null) {
-            this.http.setHeaders('X-Consul-Token': token)
-        }
-
-        def originalParser = this.http.parser.getAt(ContentType.JSON)
-        this.http.parser.putAt(ContentType.JSON, { HttpResponseDecorator resp ->
-            if (resp.status >= 200 && resp.status < 300 ){
-                return originalParser(resp)
-            } else {
-                throw new GroovyRuntimeException("Unexpected response status code: ${resp.status}:" +
-                        " ${resp.getEntity().getContent().getText("UTF-8")}")
-            }
-        })
+    SimpleConsulClient(RESTClient http) {
+        this.http = http
     }
 
     boolean isLeaderElected() {

--- a/src/test/groovy/com/pszymczyk/consul/ConsulTestWaiter.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulTestWaiter.groovy
@@ -1,6 +1,7 @@
 package com.pszymczyk.consul
 
 import com.ecwid.consul.v1.ConsulClient
+import com.ecwid.consul.v1.QueryParams
 import com.pszymczyk.consul.infrastructure.ConsulWaiter
 
 import java.util.concurrent.TimeUnit
@@ -20,6 +21,12 @@ class ConsulTestWaiter extends ConsulWaiter {
     void awaitUntilServiceRegistered(String id) {
         await().atMost(30, TimeUnit.SECONDS).until({
             consulClient.getAgentServices().getValue().values().findAll({ id == it.id }).size() == 1
+        })
+    }
+
+    void awaitConsulServiceRegistered() {
+        await().atMost(30, TimeUnit.SECONDS).until({
+            !consulClient.getCatalogServices(QueryParams.DEFAULT).getValue().isEmpty()
         })
     }
 }

--- a/src/test/groovy/com/pszymczyk/consul/ConsulTestWaiter.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulTestWaiter.groovy
@@ -24,9 +24,9 @@ class ConsulTestWaiter extends ConsulWaiter {
         })
     }
 
-    void awaitConsulServiceRegistered() {
+    void awaitConsulServiceRegistered(String token = null) {
         await().atMost(30, TimeUnit.SECONDS).until({
-            !consulClient.getCatalogServices(QueryParams.DEFAULT).getValue().isEmpty()
+            !consulClient.getCatalogServices(QueryParams.DEFAULT, token).getValue().isEmpty()
         })
     }
 }

--- a/src/test/groovy/com/pszymczyk/consul/ConsulTestWaiter.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulTestWaiter.groovy
@@ -13,7 +13,7 @@ class ConsulTestWaiter extends ConsulWaiter {
     ConsulClient consulClient
 
     ConsulTestWaiter(String host, int port) {
-        super(host, port)
+        super(host, port, null)
         this.consulClient = new ConsulClient(host, port)
     }
 

--- a/src/test/groovy/com/pszymczyk/consul/ConsulTokenTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulTokenTest.groovy
@@ -36,7 +36,7 @@ class ConsulTokenTest extends Specification {
         ConsulTestWaiter consulWaiter = new ConsulTestWaiter('localhost', consul.httpPort)
 
         then:
-        consulWaiter.awaitConsulServiceRegistered()
+        consulWaiter.awaitConsulServiceRegistered(uuid)
         noExceptionThrown()
 
         cleanup:

--- a/src/test/groovy/com/pszymczyk/consul/ConsulTokenTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/ConsulTokenTest.groovy
@@ -1,0 +1,229 @@
+package com.pszymczyk.consul
+
+import com.ecwid.consul.v1.ConsulClient
+import com.ecwid.consul.v1.OperationException
+import com.ecwid.consul.v1.kv.model.PutParams
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+
+class ConsulTokenTest extends Specification {
+
+
+    /**
+     * TODO: Config for ACL will be changed since 1.4.0, so we will have to change these tests,
+     * once we set default consul version to 1.4.0 or higher
+     */
+    def "should start secured consul with configured token"() {
+        when:
+        def uuid = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+          "acl_datacenter": "us",
+          "acl_default_policy": "deny",
+          "acl_agent_master_token": ${uuid},
+          "acl_master_token": ${uuid},
+          "acl_agent_token": ${uuid},
+          "acl_enable_key_list_policy": true,
+          "acl_down_policy": "deny"
+        }"""
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withToken(uuid)
+                .withCustomConfig(conf)
+                .build().start()
+
+        ConsulTestWaiter consulWaiter = new ConsulTestWaiter('localhost', consul.httpPort)
+
+        then:
+        consulWaiter.awaitConsulServiceRegistered()
+        noExceptionThrown()
+
+        cleanup:
+        consul.close()
+    }
+
+    def "unable to start secured consul with wrong token"() {
+        when:
+        def token = UUID.randomUUID().toString()
+        def wrongToken = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+          "acl_datacenter": "us",
+          "acl_default_policy": "deny",
+          "acl_master_token": ${token},
+          "acl_enable_key_list_policy": true,
+          "acl_down_policy": "deny"
+        }"""
+
+        ConsulStarterBuilder.consulStarter()
+                .withToken(wrongToken)
+                .withCustomConfig(conf)
+                .withWaitTimeout(3)
+                .build().start()
+
+        then:
+        def ex = thrown EmbeddedConsulException
+        ex.message =~ "Could not start Consul*"
+
+    }
+
+    def "should start consul without token"() {
+        when:
+        def token = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+        }"""
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withToken(token)
+                .withCustomConfig(conf)
+                .build().start()
+
+        ConsulTestWaiter consulWaiter = new ConsulTestWaiter('localhost', consul.httpPort)
+
+        then:
+        consulWaiter.awaitConsulServiceRegistered()
+        noExceptionThrown()
+
+        cleanup:
+        consul.close()
+    }
+
+    def "unable to start secured consul without token"() {
+        when:
+        def token = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+          "acl_datacenter": "us",
+          "acl_default_policy": "deny",
+          "acl_master_token": ${token},
+          "acl_enable_key_list_policy": true,
+          "acl_down_policy": "deny"
+        }"""
+
+        ConsulStarterBuilder.consulStarter()
+                .withCustomConfig(conf)
+                .build().start()
+
+        then:
+        def ex = thrown EmbeddedConsulException
+        ex.message =~ "Could not start Consul*"
+    }
+
+    def "client should not call secured consul without ACL"() {
+        when:
+        def uuid = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+          "acl_datacenter": "us",
+          "acl_default_policy": "deny",
+          "acl_master_token": ${uuid},
+          "acl_agent_master_token": ${uuid},
+          "acl_agent_token": ${uuid}
+        }"""
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withToken(uuid)
+                .withCustomConfig(conf)
+                .build().start()
+
+        ConsulClient consulClient = new ConsulClient("localhost", consul.httpPort)
+        consulClient.setKVValue("key", "value")
+
+        consulClient.getKVValue("key")
+
+        then:
+        OperationException ex = thrown OperationException
+        ex.statusCode == 403
+
+        cleanup:
+        consul.close()
+    }
+
+    def "client should be able to call secured consul with correct ACL"() {
+        when:
+        def uuid = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+          "acl_datacenter": "us",
+          "acl_default_policy": "deny",
+          "acl_master_token": ${uuid},
+          "acl_agent_master_token": ${uuid},
+          "acl_agent_token": ${uuid}
+        }"""
+
+        final String key = "key"
+        final String value = "value"
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withToken(uuid)
+                .withCustomConfig(conf)
+                .build().start()
+
+        ConsulClient consulClient = new ConsulClient("localhost", consul.httpPort)
+        consulClient.setKVValue(key, value, uuid, new PutParams())
+        String actualValue = consulClient.getKVValue(key, uuid).getValue().getDecodedValue(Charset.defaultCharset())
+
+        then:
+        noExceptionThrown()
+        actualValue == value
+
+        cleanup:
+        consul.close()
+    }
+
+    def "client should be able to call unsecured consul without token"() {
+        when:
+        def uuid = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us"
+        }"""
+
+        final String key = "key"
+        final String value = "value"
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withToken(uuid)
+                .withCustomConfig(conf)
+                .build().start()
+
+        ConsulClient consulClient = new ConsulClient("localhost", consul.httpPort)
+        consulClient.setKVValue(key, value, uuid, new PutParams())
+        String actualValue = consulClient.getKVValue(key, uuid).getValue().getDecodedValue(Charset.defaultCharset())
+
+        then:
+        noExceptionThrown()
+        actualValue == value
+
+        cleanup:
+        consul.close()
+    }
+
+
+    def "client should be able to call unsecured consul with token"() {
+        when:
+        def conf = """{
+          "datacenter": "us"
+        }"""
+
+        final String key = "key"
+        final String value = "value"
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withCustomConfig(conf)
+                .build().start()
+
+        ConsulClient consulClient = new ConsulClient("localhost", consul.httpPort)
+        consulClient.setKVValue(key, value, new PutParams())
+        String actualValue = consulClient.getKVValue(key).getValue().getDecodedValue(Charset.defaultCharset())
+
+        then:
+        noExceptionThrown()
+        actualValue == value
+
+        cleanup:
+        consul.close()
+    }
+
+}

--- a/src/test/groovy/com/pszymczyk/consul/MultipleProcessesTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/MultipleProcessesTest.groovy
@@ -36,6 +36,7 @@ class MultipleProcessesTest extends Specification implements AwaitilityTrait {
                 .withBind("127.0.0.1")
                 .withClient("127.0.0.1")
                 .withAdvertise("127.0.0.1")
+                .withWaitTimeout(5)
                 .build().start()
         ConsulClient consulClient1 = new ConsulClient("127.0.0.1", consul1.httpPort)
         ConsulProcess consul2 = ConsulStarterBuilder.consulStarter()
@@ -43,6 +44,7 @@ class MultipleProcessesTest extends Specification implements AwaitilityTrait {
                 .withBind("127.0.0.10")
                 .withClient("127.0.0.10")
                 .withAdvertise("127.0.0.10")
+                .withWaitTimeout(5)
                 .build().start()
         ConsulClient consulClient2 = new ConsulClient("127.0.0.10", consul2.httpPort)
         ConsulProcess consul3 = ConsulStarterBuilder.consulStarter()
@@ -50,6 +52,7 @@ class MultipleProcessesTest extends Specification implements AwaitilityTrait {
                 .withBind("127.0.0.11")
                 .withClient("127.0.0.11")
                 .withAdvertise("127.0.0.11")
+                .withWaitTimeout(5)
                 .build().start()
         ConsulClient consulClient3 = new ConsulClient("127.0.0.11", consul3.httpPort)
 

--- a/src/test/groovy/com/pszymczyk/consul/infrastructure/ConsulWaiterTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/infrastructure/ConsulWaiterTest.groovy
@@ -1,5 +1,9 @@
 package com.pszymczyk.consul.infrastructure
 
+import com.ecwid.consul.v1.ConsulClient
+import com.pszymczyk.consul.ConsulProcess
+import com.pszymczyk.consul.ConsulStarter
+import com.pszymczyk.consul.ConsulStarterBuilder
 import com.pszymczyk.consul.EmbeddedConsulException
 import spock.lang.Specification
 
@@ -14,4 +18,80 @@ class ConsulWaiterTest extends Specification {
         def ex = thrown EmbeddedConsulException
         ex.message =~ "Could not start Consul*"
     }
+
+
+    def "should use token to get list of registered nodes"() {
+        when:
+        def uuid = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+          "acl_datacenter": "us",
+          "acl_default_policy": "deny",
+          "acl_agent_master_token": ${uuid},
+          "acl_master_token": ${uuid},
+          "acl_agent_token": ${uuid},
+          "acl_token": ${uuid},
+          "acl_enable_key_list_policy": true,
+          "acl_down_policy": "deny"
+        }"""
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withToken(uuid)
+                .withCustomConfig(conf)
+                .withConsulVersion("1.0.0")
+                .build().start()
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        consul.close()
+    }
+
+    def "unable to get registered nodes with wrong token"() {
+        when:
+        def token = UUID.randomUUID().toString()
+        def wrongToken = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+          "acl_datacenter": "us",
+          "acl_default_policy": "deny",
+          "acl_master_token": ${token},
+          "acl_enable_key_list_policy": true,
+          "acl_down_policy": "deny"
+        }"""
+
+        ConsulStarterBuilder.consulStarter()
+                .withToken(wrongToken)
+                .withCustomConfig(conf)
+                .withConsulVersion("1.0.0")
+                .withWaitTimeout(3)
+                .build().start()
+
+        then:
+        def ex = thrown EmbeddedConsulException
+        ex.message =~ "Could not start Consul*"
+
+    }
+
+    def "should get registered nodes with token for consul without token"() {
+        when:
+        def token = UUID.randomUUID().toString()
+        def conf = """{
+          "datacenter": "us",
+        }"""
+
+        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
+                .withToken(token)
+                .withCustomConfig(conf)
+                .withConsulVersion("1.0.0")
+                .build().start()
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        consul.close()
+    }
+
 }

--- a/src/test/groovy/com/pszymczyk/consul/infrastructure/ConsulWaiterTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/infrastructure/ConsulWaiterTest.groovy
@@ -1,97 +1,19 @@
 package com.pszymczyk.consul.infrastructure
 
-import com.ecwid.consul.v1.ConsulClient
+
 import com.pszymczyk.consul.ConsulProcess
-import com.pszymczyk.consul.ConsulStarter
 import com.pszymczyk.consul.ConsulStarterBuilder
+import com.pszymczyk.consul.ConsulTestWaiter
 import com.pszymczyk.consul.EmbeddedConsulException
 import spock.lang.Specification
 
-
 class ConsulWaiterTest extends Specification {
 
-    def "should throw exception when timed out"() {
+    def "should return false when timed out"() {
         when:
-        new ConsulWaiter("localhost", 0, 1).awaitUntilConsulStarted()
+        boolean started = new ConsulWaiter("localhost", 0, null,1).awaitUntilConsulStarted()
 
         then:
-        def ex = thrown EmbeddedConsulException
-        ex.message =~ "Could not start Consul*"
+        !started
     }
-
-
-    def "should use token to get list of registered nodes"() {
-        when:
-        def uuid = UUID.randomUUID().toString()
-        def conf = """{
-          "datacenter": "us",
-          "acl_datacenter": "us",
-          "acl_default_policy": "deny",
-          "acl_agent_master_token": ${uuid},
-          "acl_master_token": ${uuid},
-          "acl_agent_token": ${uuid},
-          "acl_token": ${uuid},
-          "acl_enable_key_list_policy": true,
-          "acl_down_policy": "deny"
-        }"""
-
-        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
-                .withToken(uuid)
-                .withCustomConfig(conf)
-                .withConsulVersion("1.0.0")
-                .build().start()
-
-        then:
-        noExceptionThrown()
-
-        cleanup:
-        consul.close()
-    }
-
-    def "unable to get registered nodes with wrong token"() {
-        when:
-        def token = UUID.randomUUID().toString()
-        def wrongToken = UUID.randomUUID().toString()
-        def conf = """{
-          "datacenter": "us",
-          "acl_datacenter": "us",
-          "acl_default_policy": "deny",
-          "acl_master_token": ${token},
-          "acl_enable_key_list_policy": true,
-          "acl_down_policy": "deny"
-        }"""
-
-        ConsulStarterBuilder.consulStarter()
-                .withToken(wrongToken)
-                .withCustomConfig(conf)
-                .withConsulVersion("1.0.0")
-                .withWaitTimeout(3)
-                .build().start()
-
-        then:
-        def ex = thrown EmbeddedConsulException
-        ex.message =~ "Could not start Consul*"
-
-    }
-
-    def "should get registered nodes with token for consul without token"() {
-        when:
-        def token = UUID.randomUUID().toString()
-        def conf = """{
-          "datacenter": "us",
-        }"""
-
-        ConsulProcess consul = ConsulStarterBuilder.consulStarter()
-                .withToken(token)
-                .withCustomConfig(conf)
-                .withConsulVersion("1.0.0")
-                .build().start()
-
-        then:
-        noExceptionThrown()
-
-        cleanup:
-        consul.close()
-    }
-
 }


### PR DESCRIPTION
As current implementation supports custom config, which allows to enable ACLs
we should support this configuration. However, current implementation of `ConsulWaiter` and its inner http client does not support tokens, though send requests to Consul, which makes impossible to use embedded-consul for tokens