### PR TITLE
To resolve the failure of running test singlely due to http client dependency conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@ dependencies {
 
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'org.apache.httpcomponents:httpclient:4.5.5'
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '5.6'
 }

--- a/src/test/groovy/com/pszymczyk/consul/MultipleProcessesTest.groovy
+++ b/src/test/groovy/com/pszymczyk/consul/MultipleProcessesTest.groovy
@@ -7,7 +7,6 @@ import com.jayway.awaitility.groovy.AwaitilityTrait
 import spock.lang.Requires
 import spock.lang.Specification
 
-@Requires({ os.linux })
 class MultipleProcessesTest extends Specification implements AwaitilityTrait {
 
     def "should run multiple Consul processes simultaneously"() {
@@ -32,6 +31,7 @@ class MultipleProcessesTest extends Specification implements AwaitilityTrait {
         consul2.close()
     }
 
+    @Requires({ os.linux })
     def "should run multiple Consul processes with same port simultaneously"() {
         when:
         ConsulProcess consul1 = ConsulStarterBuilder.consulStarter()


### PR DESCRIPTION
Executing test with `gradle` is ok but fail while runs singly as below picture shows:

![image](https://user-images.githubusercontent.com/17768055/66399157-a5e36e80-ea11-11e9-9d57-03908047d7a1.png)

I tried to solve the problem by forcing `org.apache.httpcomponents:httpclient:4.5.5` to be used in project