### PR TITLE
Test project with OpenJDK 8, 11 and 15 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: groovy
 
 jdk:
   - openjdk8
+  - openjdk11
+  - openjdk15
 
 script:
   - "./gradlew check"


### PR DESCRIPTION
Just to have at least base path automatically tested with different OpenJDK versions.