### PR TITLE
Reduce groovy transitive dependencies to minimum

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,12 @@ repositories {
     mavenCentral()
 }
 
+ext.groovyVersion = '2.5.13'
+
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.5.13'
+    compile "org.codehaus.groovy:groovy:$groovyVersion"
+    compile "org.codehaus.groovy:groovy-json:$groovyVersion"
+    compile "org.codehaus.groovy:groovy-ant:$groovyVersion"
     compile 'org.apache.ant:ant:1.10.8'
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     compile 'org.slf4j:slf4j-api:1.7.30'


### PR DESCRIPTION
With groovy-all all groovy modules were added as production transitive dependencies for embedded-consul.

Before:
```
compileClasspath - Compile classpath for source set 'main'.
+--- org.codehaus.groovy:groovy-all:2.5.13
|    +--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-ant:2.5.13
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    +--- org.apache.ant:ant:1.9.15 -> 1.10.8
|    |    |    \--- org.apache.ant:ant-launcher:1.10.8
|    |    \--- org.codehaus.groovy:groovy-groovydoc:2.5.13
|    |         +--- org.codehaus.groovy:groovy-templates:2.5.13
|    |         |    +--- org.codehaus.groovy:groovy:2.5.13
|    |         |    \--- org.codehaus.groovy:groovy-xml:2.5.13
|    |         |         \--- org.codehaus.groovy:groovy:2.5.13
|    |         +--- org.codehaus.groovy:groovy:2.5.13
|    |         \--- org.codehaus.groovy:groovy-cli-picocli:2.5.13
|    |              +--- org.codehaus.groovy:groovy:2.5.13
|    |              \--- info.picocli:picocli:4.3.2
|    +--- org.codehaus.groovy:groovy-cli-commons:2.5.13
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    \--- commons-cli:commons-cli:1.4
|    +--- org.codehaus.groovy:groovy-cli-picocli:2.5.13 (*)
|    +--- org.codehaus.groovy:groovy-console:2.5.13
|    |    +--- org.codehaus.groovy:groovy-templates:2.5.13 (*)
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    +--- org.codehaus.groovy:groovy-cli-picocli:2.5.13 (*)
|    |    \--- org.codehaus.groovy:groovy-swing:2.5.13
|    |         \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-datetime:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-docgenerator:2.5.13
|    |    +--- org.codehaus.groovy:groovy-templates:2.5.13 (*)
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    +--- org.codehaus.groovy:groovy-cli-picocli:2.5.13 (*)
|    |    \--- com.thoughtworks.qdox:qdox:1.12.1
|    +--- org.codehaus.groovy:groovy-groovydoc:2.5.13 (*)
|    +--- org.codehaus.groovy:groovy-groovysh:2.5.13
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    +--- org.codehaus.groovy:groovy-cli-picocli:2.5.13 (*)
|    |    +--- org.codehaus.groovy:groovy-console:2.5.13 (*)
|    |    \--- jline:jline:2.14.6
|    +--- org.codehaus.groovy:groovy-jmx:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-json:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-jsr223:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-macro:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-nio:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-servlet:2.5.13
|    |    +--- org.codehaus.groovy:groovy-templates:2.5.13 (*)
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    \--- org.codehaus.groovy:groovy-xml:2.5.13 (*)
|    +--- org.codehaus.groovy:groovy-sql:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.codehaus.groovy:groovy-swing:2.5.13 (*)
|    +--- org.codehaus.groovy:groovy-templates:2.5.13 (*)
|    +--- org.codehaus.groovy:groovy-test:2.5.13
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    \--- junit:junit:4.12 -> 4.13
|    |         \--- org.hamcrest:hamcrest-core:1.3
|    +--- org.codehaus.groovy:groovy-test-junit5:2.5.13
|    |    +--- org.codehaus.groovy:groovy:2.5.13
|    |    +--- org.junit.jupiter:junit-jupiter-api:5.4.2 -> 5.7.0
|    |    |    +--- org.junit:junit-bom:5.7.0
|    |    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.7.0 (c)
|    |    |    |    +--- org.junit.platform:junit-platform-commons:1.7.0 (c)
|    |    |    |    +--- org.junit.platform:junit-platform-launcher:1.7.0 (c)
|    |    |    |    \--- org.junit.platform:junit-platform-engine:1.7.0 (c)
|    |    |    +--- org.apiguardian:apiguardian-api:1.1.0
|    |    |    +--- org.opentest4j:opentest4j:1.2.0
|    |    |    \--- org.junit.platform:junit-platform-commons:1.7.0
|    |    |         +--- org.junit:junit-bom:5.7.0 (*)
|    |    |         \--- org.apiguardian:apiguardian-api:1.1.0
|    |    \--- org.junit.platform:junit-platform-launcher:1.4.2 -> 1.7.0
|    |         +--- org.junit:junit-bom:5.7.0 (*)
|    |         \--- org.junit.platform:junit-platform-engine:1.7.0
|    |              +--- org.junit:junit-bom:5.7.0 (*)
|    |              +--- org.opentest4j:opentest4j:1.2.0
|    |              \--- org.junit.platform:junit-platform-commons:1.7.0 (*)
|    +--- org.codehaus.groovy:groovy-testng:2.5.13
|    |    \--- org.codehaus.groovy:groovy:2.5.13
|    \--- org.codehaus.groovy:groovy-xml:2.5.13 (*)
```

After:
```
compileClasspath - Compile classpath for source set 'main'.
+--- org.codehaus.groovy:groovy:2.5.13
+--- org.codehaus.groovy:groovy-json:2.5.13
|    \--- org.codehaus.groovy:groovy:2.5.13
+--- org.codehaus.groovy:groovy-ant:2.5.13
|    +--- org.codehaus.groovy:groovy:2.5.13
|    +--- org.apache.ant:ant:1.9.15 -> 1.10.8
|    |    \--- org.apache.ant:ant-launcher:1.10.8
|    \--- org.codehaus.groovy:groovy-groovydoc:2.5.13
```

This might be potentially breaking change for people (unwitting) relying on extra dependencies provided by embedded-consul. However, especially for test scope, it should not be a problem.