### PR TITLE
Add Flag to Disable Addition of Shutdown Hook

### DIFF
--- a/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulProcess.groovy
@@ -22,7 +22,7 @@ class ConsulProcess implements AutoCloseable {
     private final ConsulLogHandler consulLogHandler
 
     @PackageScope
-    ConsulProcess(Path dataDir, ConsulPorts consulPorts, String address, Process process, SimpleConsulClient simpleConsulClient, ConsulWaiter consulWaiter, ConsulLogHandler consulLogHandler) {
+    ConsulProcess(Path dataDir, ConsulPorts consulPorts, String address, Process process, SimpleConsulClient simpleConsulClient, ConsulWaiter consulWaiter, ConsulLogHandler consulLogHandler, boolean disableAddingShutdownHook) {
         this.dataDir = dataDir
         this.consulPorts = consulPorts
         this.address = address
@@ -30,7 +30,9 @@ class ConsulProcess implements AutoCloseable {
         this.simpleConsulClient = simpleConsulClient
         this.consulWaiter = consulWaiter
         this.consulLogHandler = consulLogHandler
-        addShutdownHook { this.process.destroyForcibly()}
+        if (!disableAddingShutdownHook) {
+            addShutdownHook { this.process.destroyForcibly() }
+        }
     }
     /**
      * Deregister all services except consul.

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarter.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarter.groovy
@@ -57,7 +57,7 @@ class ConsulStarter {
         logHandler.handleStream(innerProcess.getInputStream())
         SimpleConsulClient consulClient = ConsulClientFactory.newClient(userInput.advertise, userInput.consulPorts.httpPort, Optional.ofNullable(userInput.token))
         ConsulWaiter consulWaiter = new ConsulWaiter(userInput.advertise, userInput.consulPorts.httpPort, consulClient, Optional.ofNullable(userInput.waitTimeout))
-        ConsulProcess process = new ConsulProcess(userInput.dataDir, userInput.consulPorts, userInput.advertise, innerProcess, consulClient, consulWaiter, logHandler)
+        ConsulProcess process = new ConsulProcess(userInput.dataDir, userInput.consulPorts, userInput.advertise, innerProcess, consulClient, consulWaiter, logHandler, userInput.disableAddingShutdownHook)
 
         logger.info("Starting Consul process on port {}", userInput.consulPorts.httpPort)
         consulWaiter.awaitUntilConsulStarted()

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
@@ -28,6 +28,7 @@ class ConsulStarterBuilder {
     private String client = "127.0.0.1"
     private String token
     private Integer waitTimeout
+    private boolean disableAddingShutdownHook = false
 
     private ConsulStarterBuilder() {
 
@@ -113,6 +114,11 @@ class ConsulStarterBuilder {
         this
     }
 
+    ConsulStarterBuilder disableAddingShutdownHook() {
+        this.disableAddingShutdownHook = true;
+        this
+    }
+
     ConsulStarterBuilder withService(Service... serviceName) {
         this.services.addAll(serviceName)
         this
@@ -138,6 +144,7 @@ class ConsulStarterBuilder {
                 bind,
                 token,
                 waitTimeout,
+                disableAddingShutdownHook,
                 services))
     }
 

--- a/src/main/groovy/com/pszymczyk/consul/UserInput.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/UserInput.groovy
@@ -22,9 +22,10 @@ class UserInput {
     final String bind
     final String token
     final Integer waitTimeout
+    final boolean disableAddingShutdownHook
     final Set<Service> services
 
-    UserInput(Path dataDir, Path downloadDir, Path configDir, String consulVersion, CustomConfig customConfig, LogLevel logLevel, Logger customLogger, ConsulPorts.ConsulPortsBuilder consulPorts, String startJoin, String advertise, String client, String bind, String token, Integer waitTimeout, Set<Service> services) {
+    UserInput(Path dataDir, Path downloadDir, Path configDir, String consulVersion, CustomConfig customConfig, LogLevel logLevel, Logger customLogger, ConsulPorts.ConsulPortsBuilder consulPorts, String startJoin, String advertise, String client, String bind, String token, Integer waitTimeout, boolean disableAddingShutdownHook, Set<Service> services) {
         this.dataDir = dataDir
         this.downloadDir = downloadDir
         this.configDir = configDir
@@ -39,6 +40,7 @@ class UserInput {
         this.bind = bind
         this.token = token
         this.waitTimeout = waitTimeout
+        this.disableAddingShutdownHook = disableAddingShutdownHook
         this.services = services
     }
 


### PR DESCRIPTION
Adding ability to disable shutdown hook that destroys the internal process. This shutdown hook can prevent an integration test from using a similar shutdown hook to terminate itself if Consul use is in the shutdown path.