### PR TITLE
Add TravisCI job to build and test on ARM64 (Aarch64)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,7 @@ matrix:
       env: SKIP_RELEASE=true
     - jdk: openjdk15
       env: SKIP_RELEASE=true
+    - name: Linux aarch64
+      jdk: openjdk11
+      arch: arm64
+      env: SKIP_RELEASE=true


### PR DESCRIPTION
To prevent regressions in the OS/arch detection code