### PR TITLE
Bump default Consul version to 1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.2.1 - Unreleased
 
  - bump default Consul version to 1.8.6
+ - add Flag to Disable Addition of Shutdown Hook - [#113](https://github.com/pszymczyk/embedded-consul/pull/113/) - PR by [Eric Glass](https://github.com/ericnglass)
+ - restore `groovy-xml` dependency - [#114](https://github.com/pszymczyk/embedded-consul/pull/114) - PR by [Martin Grigorov](https://github.com/martin-g)
 
 ## 2.2.0 - 2020-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.1 - Unreleased
 
- - bump default Consul version to 1.8.4
+ - bump default Consul version to 1.8.6
 
 ## 2.2.0 - 2020-09-23
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Embedded Consul provides easy way to run Consul in integration tests.
 [![Build Status](https://travis-ci.org/pszymczyk/embedded-consul.svg?branch=master)](https://travis-ci.org/pszymczyk/embedded-consul)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.pszymczyk.consul/embedded-consul/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.pszymczyk.consul/embedded-consul/)
 
-Built on Consul 1.8.4 <br />
+Built on Consul 1.8.6 <br />
 Compatible with jdk1.8+. <br />
 Working on all operating systems: Mac, Linux, Windows.
 

--- a/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
+++ b/src/main/groovy/com/pszymczyk/consul/ConsulStarterBuilder.groovy
@@ -18,7 +18,7 @@ class ConsulStarterBuilder {
     private Path downloadDir
     private Path configDir
     private CustomConfig customConfig = CustomConfig.empty()
-    private String consulVersion = '1.8.4'
+    private String consulVersion = '1.8.6'
     private LogLevel logLevel = LogLevel.ERR
     private Logger customLogger
     private ConsulPorts.ConsulPortsBuilder consulPortsBuilder = ConsulPorts.consulPorts()


### PR DESCRIPTION
@pszymczyk Maybe it would be good to release 2.2.1 (having the CD machinery in place? ;-) ) - just add `[#DO_RELEASE]` in the seconds line merging that PR.

Btw, it would be good to merge https://github.com/pszymczyk/embedded-consul/pull/111 **before** the release.


